### PR TITLE
Slugify multi-word city names for URLs

### DIFF
--- a/src/app/(home)/travel/[cityName]/page.tsx
+++ b/src/app/(home)/travel/[cityName]/page.tsx
@@ -3,20 +3,30 @@ import { HydrateClient, trpc } from "@/trpc/server";
 
 type Params = Promise<{ cityName: string }>;
 
+// Helper function to format the city name
+const formatCityName = (cityName: string) => {
+  return cityName
+    .split("-")
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+};
+
 export const generateMetadata = async ({ params }: { params: Params }) => {
   const { cityName } = await params;
+  const formattedCityName = formatCityName(decodeURIComponent(cityName));
   return {
-    title: `${decodeURIComponent(cityName)} - Travel`,
+    title: `${formattedCityName} - Travel`,
   };
 };
 
 const CityPage = async ({ params }: { params: Params }) => {
   const { cityName } = await params;
-  void trpc.photos.getCitySetByCity.prefetch({ city: cityName });
+  const formattedCityName = formatCityName(decodeURIComponent(cityName));
+  void trpc.photos.getCitySetByCity.prefetch({ city: formattedCityName });
 
   return (
     <HydrateClient>
-      <CityView city={cityName} />
+      <CityView city={formattedCityName} />
     </HydrateClient>
   );
 };

--- a/src/modules/travel/ui/components/city-item.tsx
+++ b/src/modules/travel/ui/components/city-item.tsx
@@ -3,6 +3,14 @@ import { PiArrowRight } from "react-icons/pi";
 import TextScroll from "@/components/text-scroll";
 import { CitySetWithPhotos } from "@/db/schema/photos";
 
+// Slugify Function
+const slugify = (text: string) => {
+  return text
+    .toLowerCase()
+    .replace(/[\s]+/g, "-")      // Replace spaces with dashes
+    .replace(/[^\w\-]+/g, "");   // Remove special characters
+};
+
 interface CityItemProps {
   city: CitySetWithPhotos;
   onMouseEnter: (city: CitySetWithPhotos) => void;
@@ -11,12 +19,14 @@ interface CityItemProps {
 export const CityItem = ({ city, onMouseEnter }: CityItemProps) => {
   const router = useRouter();
 
+  const citySlug = slugify(city.city);
+
   return (
     <div
       key={city.id}
       className="w-full py-5 px-3 bg-muted hover:bg-muted-hover rounded-xl grid grid-cols-2 items-center cursor-pointer group transition-all duration-150 ease-[cubic-bezier(0.22, 1, 0.36, 1)] flex-1 overflow-hidden"
       onMouseEnter={() => onMouseEnter(city)}
-      onClick={() => router.push(`/travel/${city.city}`)}
+      onClick={() => router.push(`/travel/${citySlug}`)}  // Using slug in the URL
     >
       <p className="text-xs lg:text-sm line-clamp-1">{city.city}</p>
       <div className="relative overflow-hidden flex justify-end">


### PR DESCRIPTION
1. Slugify City Name for URL:
   - Implemented a `slugify` function to transform city names into SEO-friendly URLs.
   - The function:
     - Converts the city name to lowercase.
     - Replaces spaces with dashes.
     - Removes special characters.
   - This ensures consistent and clean URL structures.

2. Updated Routing Logic:
   - Modified the `onClick` handler in `CityItem` to use the slugified city name for navigation.
   - Example URL transformations:
     - `New York` ➔ `/travel/new-york`
     - `Los Angeles` ➔ `/travel/los-angeles`
     - `São Paulo` ➔ `/travel/sao-paulo`

For contact: Nicholasp.stull@gmail.com