### PR TITLE
feat: exif data in flip-card

### DIFF
--- a/src/components/flip-card.tsx
+++ b/src/components/flip-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn, formatExposureTime } from "@/lib/utils";
 import { FiCamera, FiMapPin } from "react-icons/fi";
 import { Separator } from "./ui/separator";
 import BlurImage from "./blur-image";
@@ -15,6 +15,10 @@ interface FlipCardProps extends React.HTMLAttributes<HTMLDivElement> {
   location: string;
   camera: string;
   blurData: string;
+  focalLength?: number | null;
+  fNumber?: number | null;
+  exposureTime?: number | null;
+  iso?: number | null;
   rotate?: "x" | "y";
 }
 
@@ -25,6 +29,10 @@ export default function FlipCard({
   location,
   camera,
   blurData,
+  focalLength,
+  fNumber,
+  exposureTime,
+  iso,
   rotate = "y",
   className,
   ...props
@@ -117,21 +125,35 @@ export default function FlipCard({
 
             <div className="absolute bottom-6 left-6">
               <div className="flex items-center gap-2">
-                <span className="text-white text-xs lg:text-sm font-light">
-                  ƒ/3.5
-                </span>
-                <Separator orientation="vertical" className="h-4 opacity-70" />
-                <span className="text-white text-xs lg:text-sm font-light">
-                  1/200
-                </span>
-                <Separator orientation="vertical" className="h-4 opacity-70" />
-                <span className="text-white text-xs lg:text-sm font-light">
-                  ISO100
-                </span>
-                <Separator orientation="vertical" className="h-4 opacity-70" />
-                <span className="text-white text-xs lg:text-sm font-light">
-                  45mm
-                </span>
+                {fNumber && (
+                  <>
+                    <span className="text-white text-xs lg:text-sm font-light">
+                      ƒ/{fNumber}
+                    </span>
+                    <Separator orientation="vertical" className="h-4 opacity-70" />
+                  </>
+                )}
+                {exposureTime && (
+                  <>
+                    <span className="text-white text-xs lg:text-sm font-light">
+                      {formatExposureTime(exposureTime)}
+                    </span>
+                    <Separator orientation="vertical" className="h-4 opacity-70" />
+                  </>
+                )}
+                {iso && (
+                  <>
+                    <span className="text-white text-xs lg:text-sm font-light">
+                      ISO{iso}
+                    </span>
+                    <Separator orientation="vertical" className="h-4 opacity-70" />
+                  </>
+                )}
+                {focalLength && (
+                  <span className="text-white text-xs lg:text-sm font-light">
+                    {focalLength}mm
+                  </span>
+                )}
               </div>
             </div>
           </div>

--- a/src/modules/travel/ui/sections/city-section.tsx
+++ b/src/modules/travel/ui/sections/city-section.tsx
@@ -125,6 +125,10 @@ const CitySectionSuspense = ({ city }: Props) => {
               location={photo.city + ", " + photo.country}
               camera={photo.make + " " + photo.model}
               blurData={photo.blurData}
+              focalLength={photo.focalLength35mm}
+              fNumber={photo.fNumber}
+              exposureTime={photo.exposureTime}
+              iso={photo.iso}
               rotate="y"
             />
           </AspectRatio>


### PR DESCRIPTION
This pull request includes several updates to the `FlipCard` component in `src/components/flip-card.tsx` and its usage in the `CitySectionSuspense` component in `src/modules/travel/ui/sections/city-section.tsx`. The changes enhance the `FlipCard` component by adding new optional props and updating the UI to conditionally display additional camera metadata.

Enhancements to `FlipCard` component:

* Added new optional props `focalLength`, `fNumber`, `exposureTime`, and `iso` to the `FlipCardProps` interface.
* Updated the `FlipCard` component to accept and destructure the new props.
* Modified the `FlipCard` UI to conditionally display the new camera metadata (`fNumber`, `exposureTime`, `iso`, and `focalLength`) if they are provided.
* Imported the `formatExposureTime` utility function from `@/lib/utils` to format the `exposureTime` value.

Updates to `CitySectionSuspense` component:

* Passed the new camera metadata props (`focalLength`, `fNumber`, `exposureTime`, and `iso`) to the `FlipCard` component.