### PR TITLE
fix(auth)!: enforce singleton user limit for portfolio

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "photography-next-gen",

--- a/src/modules/auth/lib/auth.ts
+++ b/src/modules/auth/lib/auth.ts
@@ -1,9 +1,11 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { createAuthMiddleware, APIError } from "better-auth/api";
 
 import { db } from "@/db";
 import * as schema from "@/db/schema";
 import { nextCookies } from "better-auth/next-js";
+import { count } from "drizzle-orm";
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
@@ -15,6 +17,30 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
   },
-  
+
   plugins: [nextCookies()],
+
+  hooks: {
+    before: createAuthMiddleware(async (ctx) => {
+      if (ctx.path !== "/sign-up/email") return;
+
+      try {
+        const result = await db.select({ value: count() }).from(schema.user);
+        const userCount = result[0]?.value ?? 0;
+
+        if (userCount > 0) {
+            throw new APIError(
+                "UNAUTHORIZED",
+                {
+                    message: "Registration is currently disabled.",
+                }
+            );
+        }
+      } catch (error) {
+          console.error("DB Hook Error:", error);
+          throw error;
+      }
+
+    })
+  }
 });


### PR DESCRIPTION
This PR addresses a security vulnerability where the registration API endpoint remained active despite the sign-up page being removed from the UI. Previously, an attacker could manually call the POST `/api/auth/sign-up/email` endpoint to create an account and gain unauthorized access to administrative features, such as uploading or removing images.

**Changes**:
- **Auth Middleware**: Added a `before` hook to the Better Auth configuration.
- **Validation Logic**: The hook now performs a database count on the `user` table for every registration attempt.
- **Enforcement**: If a user already exists in the database, the API now returns a `401 Unauthorized` error with the message: `"Registration is currently disabled."`