### PR TITLE
Fix modal scrolling

### DIFF
--- a/src/components/responsive-modal.tsx
+++ b/src/components/responsive-modal.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { cn } from "@/lib/utils";
 
 import { useIsMobile } from "@/hooks/use-mobile";
 import {
@@ -37,12 +38,14 @@ export const ResponsiveModal = ({
   if (isMobile) {
     return (
       <Drawer open={open} onOpenChange={onOpenChange}>
-        <DrawerContent className="p-4">
-          <DrawerHeader>
+        {/* Added overflow-hidden and max-h to the Drawer */}
+        <DrawerContent className="max-h-[90vh] overflow-hidden flex flex-col">
+          <DrawerHeader className="border-b shrink-0 p-4">
             <DrawerTitle>{title}</DrawerTitle>
-            <DrawerDescription></DrawerDescription>
+            <DrawerDescription />
           </DrawerHeader>
-          {children}
+          {/* Internal scrollable wrapper for Mobile */}
+          <div className="flex-1 overflow-y-auto min-h-0 p-4">{children}</div>
         </DrawerContent>
       </Drawer>
     );
@@ -50,12 +53,21 @@ export const ResponsiveModal = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={className}>
-        <DialogHeader>
+      <DialogContent
+        className={cn(
+          "p-0! max-h-[90vh]! flex! flex-col! !grid-none overflow-hidden",
+          className,
+        )}
+      >
+        <DialogHeader className="p-6 border-b shrink-0">
           <DialogTitle>{title}</DialogTitle>
-          <DialogDescription></DialogDescription>
+          <DialogDescription />
         </DialogHeader>
-        {children}
+
+        {/* Wrap the children in a scrollable flex-container */}
+        <div className="flex-1 overflow-y-auto min-h-0 w-full p-6">
+          {children}
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/responsive-modal.tsx
+++ b/src/components/responsive-modal.tsx
@@ -38,14 +38,14 @@ export const ResponsiveModal = ({
   if (isMobile) {
     return (
       <Drawer open={open} onOpenChange={onOpenChange}>
-        {/* Added overflow-hidden and max-h to the Drawer */}
-        <DrawerContent className="max-h-[90vh] overflow-hidden flex flex-col">
-          <DrawerHeader className="border-b shrink-0 p-4">
+        {/* Added overflow-hidden and max-h to the drawer */}
+        <DrawerContent className="p-0 max-h-[95vh] overflow-hidden">
+          <DrawerHeader className="p-4 border-b">
             <DrawerTitle>{title}</DrawerTitle>
-            <DrawerDescription />
+            <DrawerDescription></DrawerDescription>
           </DrawerHeader>
-          {/* Internal scrollable wrapper for Mobile */}
-          <div className="flex-1 overflow-y-auto min-h-0 p-4">{children}</div>
+          {/* Internal wrapper to handle scrolling */}
+          <div className="overflow-y-auto p-4 flex-1">{children}</div>
         </DrawerContent>
       </Drawer>
     );
@@ -53,18 +53,23 @@ export const ResponsiveModal = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* Change: We force !flex and !flex-col here. 
+         We also move padding p-6 from the dialog to an internal wrapper.
+      */}
       <DialogContent
         className={cn(
-          "p-0! max-h-[90vh]! flex! flex-col! !grid-none overflow-hidden",
+          "!p-0 !max-h-[90vh] !flex !flex-col !grid-none overflow-hidden",
           className,
         )}
       >
         <DialogHeader className="p-6 border-b shrink-0">
           <DialogTitle>{title}</DialogTitle>
-          <DialogDescription />
+          <DialogDescription></DialogDescription>
         </DialogHeader>
 
-        {/* Wrap the children in a scrollable flex-container */}
+        {/* THIS IS THE KEY: A wrapper that takes all remaining space
+           and forces scrolling.
+        */}
         <div className="flex-1 overflow-y-auto min-h-0 w-full p-6">
           {children}
         </div>

--- a/src/modules/photos/ui/components/photo-upload-modal.tsx
+++ b/src/modules/photos/ui/components/photo-upload-modal.tsx
@@ -3,28 +3,23 @@
 import { ResponsiveModal } from "@/components/responsive-modal";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { PhotoUploader } from "./photo-uploader";
-import { useState } from "react";
 
 interface PhotoUploadModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-export const PhotoUploadModal = ({open, onOpenChange}: PhotoUploadModalProps) => {
-  const [isUploading, setIsUploading] = useState(false);
-
+export const PhotoUploadModal = ({
+  open,
+  onOpenChange,
+}: PhotoUploadModalProps) => {
   return (
-    <>
-      <ResponsiveModal
-        title="Upload a photo"
-        open={isUploading || open}
-        onOpenChange={onOpenChange}
-        className="h-[80vh] w-[80vw] max-w-none"
-      >
-        <ScrollArea className="pr-4">
-          <PhotoUploader onCreateSuccess={() => setIsUploading(false)} />
-        </ScrollArea>
-      </ResponsiveModal>
-    </>
+    <ResponsiveModal
+      title="Upload Photo"
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <PhotoUploader onCreateSuccess={() => onOpenChange(false)} />
+    </ResponsiveModal>
   );
 };


### PR DESCRIPTION
Layout Constraint Issue: The DialogContent in ResponsiveModal was using a default CSS Grid layout. This allowed the modal to expand vertically to fit the entire multi-step form, pushing the "Next" and "Back" buttons off-screen on most display resolutions.